### PR TITLE
feat: allow `_extra_tasks` when running ctt

### DIFF
--- a/copier_template_tester/_write_output.py
+++ b/copier_template_tester/_write_output.py
@@ -153,7 +153,9 @@ def write_output(*, src_path: Path, dst_path: Path, data: dict[str, bool | int |
         kwargs.setdefault('quiet', False)
         kwargs.setdefault('unsafe', True)
         kwargs.setdefault('vcs_ref', 'HEAD')
-        copier.run_copy(str(src_path), dst_path, **kwargs)
+
+        with copier.Worker(src_path=str(src_path), dst_path=Path(dst_path), **kwargs) as worker:
+            worker.run_copy()
 
         # Remove any .git directory created by copier script
         git_path = dst_path / '.git'

--- a/copier_template_tester/_write_output.py
+++ b/copier_template_tester/_write_output.py
@@ -138,7 +138,13 @@ def _remove_readonly(func, path: str, _excinfo) -> None:  # noqa: ANN001
     func(path)
 
 
-def write_output(*, src_path: Path, dst_path: Path, data: dict[str, bool | int | float | str | None], **kwargs) -> None:
+def write_output(
+    *,
+    src_path: Path,
+    dst_path: Path, data: dict[str, bool | int | float | str | None],
+    extra_tasks: list[str | list[str] | dict] | None = None,
+    **kwargs,
+) -> None:
     """Copy the specified directory to the target location with provided data.
 
     kwargs documentation: https://github.com/copier-org/copier/blob/103828b59fd9eb671b5ffa909004d1577742300b/copier/main.py#L86-L173
@@ -155,6 +161,7 @@ def write_output(*, src_path: Path, dst_path: Path, data: dict[str, bool | int |
         kwargs.setdefault('vcs_ref', 'HEAD')
 
         with copier.Worker(src_path=str(src_path), dst_path=Path(dst_path), **kwargs) as worker:
+            worker.template.config_data['tasks'] = worker.template.config_data.get('tasks', []) + extra_tasks
             worker.run_copy()
 
         # Remove any .git directory created by copier script

--- a/copier_template_tester/main.py
+++ b/copier_template_tester/main.py
@@ -41,7 +41,11 @@ def run(*, base_dir: Path | None = None, check_untracked: bool = False) -> None:
         output_path = base_dir / key
         paths.add(output_path)
         logger.text(f'Using `copier` to create: {key}')
-        write_output(src_path=input_path, dst_path=base_dir / output_path, data=defaults | data)
+        data_with_defaults = defaults | data
+        extra_tasks = data_with_defaults.pop('_extra_tasks', [])
+        write_output(
+            src_path=input_path, dst_path=base_dir / output_path, data=data_with_defaults, extra_tasks=extra_tasks,
+        )
 
     if check_untracked:  # pragma: no cover
         check_for_untracked(base_dir)

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,22 @@ package_name = "testing-no-all"
 include_all = false
 ```
 
+#### Extra tasks
+
+Anything in the `_extra_tasks` key will be run after that project is generated. This is useful for running tests or other tasks that are not part of the copier template.
+
+```toml
+[defaults]
+_extra_tasks = [
+  "pre-commit run --all-files",
+]
+
+[output.".ctt/also-run-pytest-here"]
+_extra_tasks = [
+  "poetry run pytest",
+]
+```
+
 ### Pre-Commit Hook
 
 First, add this section to your `.pre-commit-config.yml` file:

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Feat
+
+- add option to run extra tasks in each generated project
+
 ## 2.1.3 (2024-07-08)
 
 ### Fix

--- a/tests/data/copier_demo/ctt.toml
+++ b/tests/data/copier_demo/ctt.toml
@@ -1,6 +1,11 @@
 # Configuration for: https://github.com/KyleKing/copier-template-tester
 
 [defaults]
+_extra_tasks = [
+  "echo task_string",
+  ["echo", "task_list"],
+  {command = "echo task_dict"},
+]
 project_name = "placeholder"
 
 [output.".ctt/no_all"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,26 +42,31 @@ def check_run_ctt(*, shell: Subprocess, cwd: Path, subdirname: str) -> set[Path]
         '*Copying from template*',
     ])
     # Check a few of the created files:
-    return {pth.relative_to(cwd) for pth in (cwd / '.ctt').rglob('*.*') if pth.is_file()}
+    return {pth.relative_to(cwd) for pth in (cwd / '.ctt').rglob('*.*') if pth.is_file()}, ret.stdout
 
 
 def test_main(shell: Subprocess) -> None:
-    paths = check_run_ctt(shell=shell, cwd=DEMO_DIR, subdirname='no_all')
+    paths, stdout = check_run_ctt(shell=shell, cwd=DEMO_DIR, subdirname='no_all')
 
     assert Path('.ctt/no_all/README.md') in paths
     assert Path('.ctt/no_all/.copier-answers.testing_no_all.yml') in paths
     assert Path('.ctt/no_all/.copier-answers.yml') not in paths
+    stdout.matcher.fnmatch_lines_random([
+        'task_string',
+        'task_list',
+        'task_dict',
+    ])
 
 
 def test_no_answer_file_dir(shell: Subprocess) -> None:
-    paths = check_run_ctt(shell=shell, cwd=NO_ANSWER_FILE_DIR, subdirname='no_answers_file')
+    paths, _stdout = check_run_ctt(shell=shell, cwd=NO_ANSWER_FILE_DIR, subdirname='no_answers_file')
 
     assert Path('.ctt/no_answers_file/README.md') in paths
     assert not [*Path('.ctt/no_answers_file').rglob('.copier-answers*')]
 
 
 def test_with_include_dir(shell: Subprocess) -> None:
-    paths = check_run_ctt(shell=shell, cwd=WITH_INCLUDE_DIR, subdirname='copier_include')
+    paths, _stdout = check_run_ctt(shell=shell, cwd=WITH_INCLUDE_DIR, subdirname='copier_include')
 
     assert Path('.ctt/copier_include/script.py') in paths
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,10 +19,10 @@ WITH_INCLUDE_DIR = TEST_DATA_DIR / 'copier_include'
 def test_main_with_copier_mock(monkeypatch, base_dir: Path) -> None:
     """Only necessary for coverage metrics, but the .ctt/* files must exist."""
 
-    def _run_copy(src_path: str, dst_path: Path, **kwargs) -> None:
+    def _run_copy(worker) -> None:
         pass
 
-    monkeypatch.setattr(copier, 'run_copy', _run_copy)
+    monkeypatch.setattr(copier.Worker, 'run_copy', _run_copy)
 
     run(base_dir=base_dir)
 


### PR DESCRIPTION
This feature allow a user to run tasks (such as `pre-commit run --all` or `poetry run pytest`) for projects generated by ctt.

I find it a game changer for testing my templates -- it allows me to quickly run linting and testing, and verify that the initial state of the created project is clean.

This PR include added tests, updated docs, and usage example.

## Usage
To add a task, just set the `_extra_tasks` key in the `[defaults]` or in the relevant `["output.".ctt/env"]`.
The syntax for `_extra_tasks` is the same as `_tasks` from copier.

The code will inject those tasks into the config, after the regular tasks.

